### PR TITLE
Use more feature-complete date formatter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 import '@logseq/libs';
 import { BlockEntity, SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin.user';
-import 'logseq-dateutils'
-import { getDateForPageWithoutBrackets } from 'logseq-dateutils';
+import SimpleDateFormat from 'simple_dt.js';
 
 const settings: SettingSchemaDesc[] = [{
   key: 'keyboardShortcut',
@@ -18,7 +17,8 @@ const main = async () => {
     keybinding: { binding: logseq.settings?.keyboardShortcut },
   }, async () => {
     const dateFormat = (await logseq.App.getUserConfigs()).preferredDateFormat
-    const date = getDateForPageWithoutBrackets(new Date(), dateFormat);
+    const language =  (await logseq.App.getUserConfigs()).preferredLanguage
+    const date = (new SimpleDateFormat(language)).format(dateFormat, new Date())
     const homepage: BlockEntity[] = (await logseq.Editor.getPageBlocksTree(date))
     const lastItem: BlockEntity = homepage[homepage.length - 1]
     if (lastItem.content == '') {

--- a/index.ts
+++ b/index.ts
@@ -17,8 +17,8 @@ const main = async () => {
     keybinding: { binding: logseq.settings?.keyboardShortcut },
   }, async () => {
     const dateFormat = (await logseq.App.getUserConfigs()).preferredDateFormat
-    const language =  (await logseq.App.getUserConfigs()).preferredLanguage
-    const date = (new SimpleDateFormat(language)).format(dateFormat, new Date())
+    const language = (await logseq.App.getUserConfigs()).preferredLanguage
+    const date = SimpleDateFormat.get(language).format('#'+dateFormat, new Date())
     const homepage: BlockEntity[] = (await logseq.Editor.getPageBlocksTree(date))
     const lastItem: BlockEntity = homepage[homepage.length - 1]
     if (lastItem.content == '') {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@logseq/libs": "0.0.6",
-    "logseq-dateutils": "^0.0.21"
+    "simple_dt.js": "^0.1.4"
   },
   "logseq": {
     "id": "logseq-go-home-now",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,11 +1173,6 @@ lodash-es@4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-logseq-dateutils@^0.0.21:
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/logseq-dateutils/-/logseq-dateutils-0.0.21.tgz#8918f9247a2c1bd435755beccad0ef8de5b8e669"
-  integrity sha512-oxHn/CttqTl45mPZqeDL7n6FVOJALxDfHHC03GQqnehugSf82lzDiHPXkzZinMswc/2jCca5eyTLMLJjRxOFqg==
-
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -1399,6 +1394,11 @@ semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+simple_dt.js@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/simple_dt.js/-/simple_dt.js-0.1.4.tgz#c4552064714f02606acc5bea0b738443fcad4c98"
+  integrity sha512-46QVD983wbZQglYQuhfhBE5wS/Yaw1TWp9UV+ENT7EIdTDavwHhVGBk+dmsIRRyJJUPkwTep7CUwaWx8AAXqOg==
 
 snake-case@3.0.4:
   version "3.0.4"


### PR DESCRIPTION
The `logseq-dateutils` formatter supports a limited number of fixed patterns rather than a general pattern. Swap out for a formatter that builds on top of `Intl.DateTimeFormat` and has more complete format specifier coverage.  

For example, this format now works: `EEEE, d MMMM yyyy`.